### PR TITLE
specify ephemeris with `tempopulsar` call

### DIFF
--- a/libstempo/libstempo.pyx
+++ b/libstempo/libstempo.pyx
@@ -759,6 +759,13 @@ cdef class tempopulsar:
             # write
             if len(model_bytes) < 100:    
                 stdio.sprintf(self.psr[0].JPL_EPHEMERIS,"%s",<char *>model_bytes)
+
+                # older tempo2 versions use ephemeris instead of JPL_EPHEMERIS
+                # for calceph.
+                if self.psr[0].useCalceph:
+                    stdio.sprintf(self.psr[0].ephemeris,"%s",
+                                  <char *>model_bytes)
+
             else:
                 raise ValueError
 


### PR DESCRIPTION
This change lets you now specify the ephemeris when calling `tempopulsar` like:

```
psr = t2.tempopulsar(parfile, timfile, ephem='DE435')
```

The naming is a bit strange if you switch to something higher than DE430 (i.e., DE435) then `psr.ephemeris` will return the full path to de435t.bsp; however, this presents no problem other than the fact that it is ugly. This is because of a stupid naming convention in tempo2 that uses `psr.ephemeris` instead of `psr.JPL_EPHEMERIS` in the calceph code. I've put in a pull request to change the naming but this PR will work with either version.

I have tested that this method gives the same result as using the ephemeris value in the par file. This will also be useful in further developing a PINT interface that looks like libstempo as PINT requires the ephemeris to be specified manually as opposed to in the par file.