### PR TITLE
Fix issue with free spectrum GWB injection in python3

### DIFF
--- a/libstempo/toasim.py
+++ b/libstempo/toasim.py
@@ -696,7 +696,7 @@ def extrap1d(interpolator):
             return interpolator(x)
 
     def ufunclike(xs):
-        return N.array(map(pointwise, N.array(xs)))
+        return N.array(list(map(pointwise, N.array(xs))))
 
     return ufunclike
 


### PR DESCRIPTION
The free spectrum injection of a GWB (userSpec option of createGWB) uses extrap1d which extends an interpolator to use for extrapolations too. When doing so it converts a map to a numpy array and returns it.

This worked well in python2, where map returned a list, but in python3 map returns an iterator which cannot be converted to a numpy array directly and gives this error:
`TypeError: unsupported operand type(s) for ** or pow(): 'float' and 'map'`

This can be easily solved by just converting the map object to a list before converting it to a numpy array, as it is done in this pull request.