### PR TITLE
Update build in CI

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,25 +53,14 @@ jobs:
   build:
     needs: [tests]
     name: Build source distribution
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        include:
-          - os: ubuntu-latest
-            platform_id: manylinux_x86_64
-          - os: macos-latest
-            platform_id: macosx_x86_64
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.7'
     - name: Install tempo2 on mac
       if: runner.os == 'macOS'
       run: |
@@ -84,8 +73,7 @@ jobs:
         ./install_tempo2.sh
     - name: Build
       run: |
-        python -m pip install --upgrade pip setuptools
-        pip install wheel
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         make dist
     - name: Test the sdist
@@ -96,14 +84,6 @@ jobs:
         venv-sdist/bin/python -m pip install --upgrade pip setuptools
         venv-sdist/bin/python -m pip install ../dist/libstempo*.tar.gz
         venv-sdist/bin/python -c "import libstempo;print(libstempo.__version__)"
-    - name: Test the wheel
-      run: |
-        mkdir tmp2  
-        cd tmp2
-        python -m venv venv-wheel
-        venv-wheel/bin/python -m pip install --upgrade pip setuptools
-        venv-wheel/bin/python -m pip install ../dist/libstempo*.whl
-        venv-wheel/bin/python -c "import libstempo;print(libstempo.__version__)"
     - uses: actions/upload-artifact@v2
       with:
         name: dist

--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,5 @@ release: clean ## package and upload a release
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist
-	python setup.py bdist_wheel
+	#python setup.py bdist_wheel
 	ls -l dist

--- a/libstempo/eccUtils.py
+++ b/libstempo/eccUtils.py
@@ -12,16 +12,19 @@ Relevant References are:
 
 """
 
+from pathlib import Path
+
 import numpy as np
 import scipy.constants as sc
 import scipy.special as ss
-from pkg_resources import Requirement, resource_filename
 from scipy.integrate import odeint
 from scipy.interpolate import interp1d
 
 SOLAR2S = sc.G / sc.c ** 3 * 1.98855e30
 KPC2S = sc.parsec / sc.c * 1e3
 MPC2S = sc.parsec / sc.c * 1e6
+
+ECC_FILE = Path(__file__).parent / "ecc_vs_nharm.txt"
 
 
 def make_ecc_interpolant():
@@ -32,9 +35,8 @@ def make_ecc_interpolant():
 
     :returns: interpolant
     """
-    pth = resource_filename(Requirement.parse("libstempo"), "libstempo/ecc_vs_nharm.txt")
 
-    fil = np.loadtxt(pth)
+    fil = np.loadtxt(ECC_FILE)
 
     return interp1d(fil[:, 0], fil[:, 1])
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,8 @@
+def test_imports():
+    import libstempo  # noqa: F401
+    import libstempo.like  # noqa: F401
+    import libstempo.emcee  # noqa: F401
+    import libstempo.plot  # noqa: F401
+    import libstempo.toasim  # noqa:F401
+    import libstempo.eccUtils  # noqa: F401
+    import libstempo.spharmORFbasis  # noqa: F401


### PR DESCRIPTION
This PR does away with trying to build a wheel and just builds the source distribution instead. To build a wheel, we would have to package `tempo2` along with `libstempo` and that isn't in the cards right now. 

This PR also adds a fix for loading the `ecc_vs_nharm` file. For some reason this was breaking and I think we were way overdoing it before. Using the relative path to the file will work.

I also added a `test_imports.py` just to make sure all imports work.