### PR TITLE
Updating how tempo2 is found on installation

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -53,25 +53,14 @@ jobs:
   build:
     needs: [tests]
     name: Build source distribution
-    runs-on: ${{ matrix.os }}
+    runs-on: ubuntu-latest
     if: github.event_name == 'release'
-    strategy:
-      fail-fast: false
-      matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: [3.6, 3.7, 3.8, 3.9]
-        include:
-          - os: ubuntu-latest
-            platform_id: manylinux_x86_64
-          - os: macos-latest
-            platform_id: macosx_x86_64
-
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python 
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: '3.7'
     - name: Install tempo2 on mac
       if: runner.os == 'macOS'
       run: |
@@ -84,8 +73,7 @@ jobs:
         ./install_tempo2.sh
     - name: Build
       run: |
-        python -m pip install --upgrade pip setuptools
-        pip install wheel
+        python -m pip install --upgrade pip setuptools wheel
         pip install -r requirements.txt
         make dist
     - name: Test the sdist
@@ -96,14 +84,6 @@ jobs:
         venv-sdist/bin/python -m pip install --upgrade pip setuptools
         venv-sdist/bin/python -m pip install ../dist/libstempo*.tar.gz
         venv-sdist/bin/python -c "import libstempo;print(libstempo.__version__)"
-    - name: Test the wheel
-      run: |
-        mkdir tmp2  
-        cd tmp2
-        python -m venv venv-wheel
-        venv-wheel/bin/python -m pip install --upgrade pip setuptools
-        venv-wheel/bin/python -m pip install ../dist/libstempo*.whl
-        venv-wheel/bin/python -c "import libstempo;print(libstempo.__version__)"
     - uses: actions/upload-artifact@v2
       with:
         name: dist

--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
-        python -m pip install flake8 pytest black pytest-cov
+        python -m pip install -r requirements_dev.txt
         pip install -e .[astropy]
     - name: Run lint
       run: make lint

--- a/Makefile
+++ b/Makefile
@@ -78,5 +78,5 @@ release: clean ## package and upload a release
 
 dist: clean ## builds source and wheel package
 	python setup.py sdist
-	python setup.py bdist_wheel
+	#python setup.py bdist_wheel
 	ls -l dist

--- a/README.md
+++ b/README.md
@@ -5,17 +5,42 @@
 
 ## Installation
 
-To use `libstempo2`, tempo2 must be installed as a prerequisite. Currently there are two recommended methods to do this.
+To use `libstempo`, tempo2 must be installed as a prerequisite. Currently there are two recommended methods to do this.
 
 1. Install via script. 
     ```bash
     curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh | sh
     ```
     This will install the tempo2 library in a local directory (`$HOME/.local`). This method is recommended if you do not need to use tempo2 directly but just need the installation for `libstempo`.
+    This script also takes in an option argument with a path to the
+    install location. For example you could run:
+    ```bash
+    # need sudo if installing in a restricted location
+    curl -sSL https://raw.githubusercontent.com/vallis/libstempo/master/install_tempo2.sh /usr/local | sudo sh -
+    ``` 
 2. Install via the [instructions](https://bitbucket.org/psrsoft/tempo2/src/master/README.md) on the tempo2 homepage. If this method is used, the `TEMPO2` environment variable will need to be set to use `libstempo`.
+
+In either case, it is best practice to set the `TEMPO2` environment
+variable so that it can be easily discovered by `libstempo`.
 
 The `libstempo` package can be installed via `pip`:
 ```bash
+pip install libstempo
+```
+
+To use `astopy` for units:
+```bash
+pip install libstempo[astropy]
+```
+
+If you have installed `tempo2` in a location that is not in your path or not the default from `install_tempo2.sh`, you will need to install 
+`libstempo` with an environment variable (e.g. if `tempo2` is in `/opt/local/bin`)
+```bash
+TEMPO2_PREFIX=/opt/local pip install libstempo
+```
+or
+```bash
+export TEMPO2_PREFIX=/opt/local
 pip install libstempo
 ```
 

--- a/install_tempo2.sh
+++ b/install_tempo2.sh
@@ -27,3 +27,4 @@ cd ..
 
 rm -rf psrsoft-tempo2-*
 rm -rf 2020.11.1.tar.gz
+echo "Set TEMPO2 environment variable to ${TEMPO2} to make things run more smoothly."

--- a/libstempo/__init__.py
+++ b/libstempo/__init__.py
@@ -1,7 +1,6 @@
 __version__ = "2.3.5"
 
 import os
-
 from ._find_tempo2 import find_tempo2_runtime
 
 

--- a/libstempo/_find_tempo2.py
+++ b/libstempo/_find_tempo2.py
@@ -1,7 +1,8 @@
-import subprocess
 import logging
-from pathlib import Path
 import os
+import subprocess
+import warnings
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 
@@ -24,20 +25,18 @@ def find_tempo2_runtime():
         out = subprocess.check_output("which tempo2", shell=True)
         out = out.decode().strip()
     except subprocess.CalledProcessError:
-        raise RuntimeError(
-            ("tempo2 does not appear to be in your path. Please make sure the executable is in your path")
-        )
-
-    # since this would be in a bin/ directory, navigate back to root and check share/
-    share_dir = Path(out).parents[1] / "share"
-
-    if share_dir.exists():
-        # loop through all directories in share
-        for d in share_dir.iterdir():
-            if d.is_dir():
-                # if this directory contains the runtime dirs then set this to be the runtime dir
-                dirs = [dd.stem for dd in d.iterdir() if dd.is_dir()]
-                if all(rd in dirs for rd in RUNTIME_DIRS):
-                    return str(d)
+        warnings.warn("Could not find tempo2 executable in your path")
     else:
-        raise FileNotFoundError(f"Directory {str(share_dir)} does not exist. Can't find T2runtime")
+
+        # since this would be in a bin/ directory, navigate back to root and check share/
+        share_dir = Path(out).parents[1] / "share"
+
+        if share_dir.exists():
+            # loop through all directories in share
+            for d in share_dir.iterdir():
+                if d.is_dir():
+                    # if this directory contains the runtime dirs then set this to be the runtime dir
+                    dirs = [dd.stem for dd in d.iterdir() if dd.is_dir()]
+                    if all(rd in dirs for rd in RUNTIME_DIRS):
+                        return str(d)
+    raise RuntimeError(f"Can't find T2runtime from inspection. Set TEMPO2 environment variable")

--- a/libstempo/_find_tempo2.py
+++ b/libstempo/_find_tempo2.py
@@ -39,4 +39,4 @@ def find_tempo2_runtime():
                     dirs = [dd.stem for dd in d.iterdir() if dd.is_dir()]
                     if all(rd in dirs for rd in RUNTIME_DIRS):
                         return str(d)
-    raise RuntimeError(f"Can't find T2runtime from inspection. Set TEMPO2 environment variable")
+    raise RuntimeError("Can't find T2runtime from inspection. Set TEMPO2 environment variable")

--- a/libstempo/eccUtils.py
+++ b/libstempo/eccUtils.py
@@ -12,16 +12,19 @@ Relevant References are:
 
 """
 
+from pathlib import Path
+
 import numpy as np
 import scipy.constants as sc
 import scipy.special as ss
-from pkg_resources import Requirement, resource_filename
 from scipy.integrate import odeint
 from scipy.interpolate import interp1d
 
 SOLAR2S = sc.G / sc.c ** 3 * 1.98855e30
 KPC2S = sc.parsec / sc.c * 1e3
 MPC2S = sc.parsec / sc.c * 1e6
+
+ECC_FILE = Path(__file__).parent / "ecc_vs_nharm.txt"
 
 
 def make_ecc_interpolant():
@@ -32,9 +35,8 @@ def make_ecc_interpolant():
 
     :returns: interpolant
     """
-    pth = resource_filename(Requirement.parse("libstempo"), "libstempo/ecc_vs_nharm.txt")
 
-    fil = np.loadtxt(pth)
+    fil = np.loadtxt(ECC_FILE)
 
     return interp1d(fil[:, 0], fil[:, 1])
 

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,7 @@
 import os
 import platform
 import subprocess
+import warnings
 from pathlib import Path
 
 import numpy
@@ -8,10 +9,17 @@ from Cython.Build import cythonize
 from setuptools import Extension, setup
 
 
-# we assume that you have either installed tempo2 via install_tempo2.sh
+# we assume that you have either installed tempo2 via install_tempo2.sh in the default location
 # or you have installed in the usual /usr/local
+# or you have set the TEMPO2_PREFIX environment variable
 # or the tempo2 executable is in your path
 def _get_tempo2_install_location():
+
+    # from environment variable
+    tempo2_environ = os.getenv("TEMPO2_PREFIX")
+    if tempo2_environ is not None:
+        return tempo2_environ
+
     # first check local install
     local = Path(os.getenv("HOME")) / ".local"
     if (local / "include/tempo2.h").exists():
@@ -27,17 +35,26 @@ def _get_tempo2_install_location():
         out = subprocess.check_output("which tempo2", shell=True)
         out = out.decode().strip()
     except subprocess.CalledProcessError:
-        raise subprocess.CalledProcessError(
-            ("tempo2 does not appear to be in your path. Please make sure the executable is in your path")
-        )
-
-    # the executable should be in in bin/ so navigate back and check include/
-    root_dir = Path(out).parents[1]
-    if (root_dir / "include/tempo2.h").exists():
-        return str(root_dir)
+        warnings.warn(("tempo2 does not appear to be in your path."))
+    else:
+        # the executable should be in in bin/ so navigate back and check include/
+        root_dir = Path(out).parents[1]
+        if (root_dir / "include/tempo2.h").exists():
+            return str(root_dir)
 
     raise RuntimeError(
-        "Cannot find tempo2 install location. Use install_tempo2.sh script to install or install globally."
+        """
+        Cannot find tempo2 install location. Your options are:
+
+        1. Use the install_tempo2.sh script without any arguments to install to default location.
+        2. Install tempo2 globally in /usr/local
+        3. Set the TEMPO2_PREFIX environment variable:
+            For example, if the tempo2 executable lives in /opt/local/bin:
+                TEMPO2_PREFIX=/opt/local pip install libstempo
+                or
+                export TEMPO2_PREFIX=/opt/local
+                pip install libstempo
+        """
     )
 
 

--- a/tests/test_imports.py
+++ b/tests/test_imports.py
@@ -1,0 +1,8 @@
+def test_imports():
+    import libstempo  # noqa: F401
+    import libstempo.like  # noqa: F401
+    import libstempo.emcee  # noqa: F401
+    import libstempo.plot  # noqa: F401
+    import libstempo.toasim  # noqa:F401
+    import libstempo.eccUtils  # noqa: F401
+    import libstempo.spharmORFbasis  # noqa: F401


### PR DESCRIPTION
This PR allows the user to set a `TEMPO2_PREFIX` when installing as a way to pass in any location for the tempo2 library. Its best not to use `--install-option` since apparently this disables creation of wheels and it breaks the build-requirements for numpy.

It also tries to provide a better error message if tempo2 cannot be found. Lastly, I've updated the README to address these installation details.

This also has the changes from my other PR in it so that one needs to be merged first