### PR TITLE
Add epoch averaged TOA sim tools

### DIFF
--- a/libstempo/toasim.py
+++ b/libstempo/toasim.py
@@ -159,7 +159,8 @@ def make_ideal(psr):
     psr.fit()
 
 
-def add_efac(psr, efac=1.0, flagid=None, flags=None, seed=None):
+def add_efac(psr, efac=1.0, flagid=None, flags=None,
+             return_vec=False, seed=None):
     """Add nominal TOA errors, multiplied by `efac` factor.
     Optionally take a pseudorandom-number-generator seed."""
 
@@ -184,8 +185,12 @@ def add_efac(psr, efac=1.0, flagid=None, flags=None, seed=None):
 
     psr.stoas[:] += efacvec * psr.toaerrs * (1e-6 / day) * N.random.randn(psr.nobs)
 
+    if return_vec:
+        return efacvec
 
-def add_equad(psr, equad, flagid=None, flags=None, seed=None):
+
+def add_equad(psr, equad, flagid=None, flags=None,
+              return_vec=False, seed=None):
     """Add quadrature noise of rms `equad` [s].
     Optionally take a pseudorandom-number-generator seed."""
 
@@ -209,6 +214,9 @@ def add_equad(psr, equad, flagid=None, flags=None, seed=None):
                 equadvec[ind] = equad[ct]
 
     psr.stoas[:] += (equadvec / day) * N.random.randn(psr.nobs)
+
+    if return_vec:
+        return equadvec
 
 
 def quantize(times, dt=1):
@@ -264,7 +272,8 @@ def quantize_fast(times, flags=None, dt=1.0):
 # print N.sum((t - t2)**2), N.all(U == U2)
 
 
-def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1, seed=None):
+def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1,
+               return_vec=False, seed=None):
     """Add correlated quadrature noise of rms `ecorr` [s],
     with coarse-graining time `coarsegrain` [days].
     Optionally take a pseudorandom-number-generator seed."""
@@ -294,6 +303,9 @@ def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1, seed=None):
                 ecorrvec[ind] = ecorr[ct]
 
     psr.stoas[:] += (1 / day) * N.dot(U * ecorrvec, N.random.randn(U.shape[1]))
+
+    if return_vec:
+        return np.dot(U * ecorrvec, np.ones(U.shape[1]))
 
 
 def add_rednoise(psr, A, gamma, components=10, seed=None):

--- a/libstempo/toasim.py
+++ b/libstempo/toasim.py
@@ -305,7 +305,7 @@ def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1,
     psr.stoas[:] += (1 / day) * N.dot(U * ecorrvec, N.random.randn(U.shape[1]))
 
     if return_vec:
-        return np.dot(U * ecorrvec, np.ones(U.shape[1]))
+        return N.dot(U * ecorrvec, N.ones(U.shape[1]))
 
 
 def add_rednoise(psr, A, gamma, components=10, seed=None):
@@ -953,7 +953,7 @@ def compute_epoch_ave(times, res, err, ecorr=None, dt=1.0, flags=None):
     from PAL2 (Ellis & van Haasteren 2017)
     https://doi.org/10.5281/zenodo.251456
     """
-    isort = np.argsort(times)
+    isort = N.argsort(times)
 
     bucket_ref = [times[isort[0]]]
     bucket_ind = [[isort[0]]]
@@ -965,23 +965,23 @@ def compute_epoch_ave(times, res, err, ecorr=None, dt=1.0, flags=None):
             bucket_ref.append(times[i])
             bucket_ind.append([i])
 
-    avetoas = np.array([np.mean(times[l]) for l in bucket_ind],'d')
+    avetoas = N.array([N.mean(times[l]) for l in bucket_ind],'d')
 
     if flags is not None:
-        aveflags = np.array([flags[l[0]] for l in bucket_ind])
+        aveflags = N.array([flags[l[0]] for l in bucket_ind])
 
-    aveerr = np.zeros(len(bucket_ind))
-    averes = np.zeros(len(bucket_ind))
+    aveerr = N.zeros(len(bucket_ind))
+    averes = N.zeros(len(bucket_ind))
 
     for i,l in enumerate(bucket_ind):
-        M = np.ones(len(l))
-        C = np.diag(err[l]**2)
+        M = N.ones(len(l))
+        C = N.diag(err[l]**2)
         if ecorr is not None:
-            C += np.ones((len(l), len(l))) * ecorr[l[0]]
+            C += N.ones((len(l), len(l))) * ecorr[l[0]]
 
-        avr = 1/np.dot(M, np.dot(np.linalg.inv(C), M))
-        aveerr[i] = np.sqrt(avr)
-        averes[i] = avr * np.dot(M, np.dot(np.linalg.inv(C), res[l]))
+        avr = 1/N.dot(M, N.dot(N.linalg.inv(C), M))
+        aveerr[i] = N.sqrt(avr)
+        averes[i] = avr * N.dot(M, N.dot(N.linalg.inv(C), res[l]))
 
     if flags is not None:
         return avetoas, aveerr, averes, aveflags

--- a/libstempo/toasim.py
+++ b/libstempo/toasim.py
@@ -159,8 +159,7 @@ def make_ideal(psr):
     psr.fit()
 
 
-def add_efac(psr, efac=1.0, flagid=None, flags=None,
-             return_vec=False, seed=None):
+def add_efac(psr, efac=1.0, flagid=None, flags=None, return_vec=False, seed=None):
     """Add nominal TOA errors, multiplied by `efac` factor.
     Optionally take a pseudorandom-number-generator seed."""
 
@@ -189,8 +188,7 @@ def add_efac(psr, efac=1.0, flagid=None, flags=None,
         return efacvec
 
 
-def add_equad(psr, equad, flagid=None, flags=None,
-              return_vec=False, seed=None):
+def add_equad(psr, equad, flagid=None, flags=None, return_vec=False, seed=None):
     """Add quadrature noise of rms `equad` [s].
     Optionally take a pseudorandom-number-generator seed."""
 
@@ -272,8 +270,7 @@ def quantize_fast(times, flags=None, dt=1.0):
 # print N.sum((t - t2)**2), N.all(U == U2)
 
 
-def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1,
-               return_vec=False, seed=None):
+def add_jitter(psr, ecorr, flagid=None, flags=None, coarsegrain=0.1, return_vec=False, seed=None):
     """Add correlated quadrature noise of rms `ecorr` [s],
     with coarse-graining time `coarsegrain` [days].
     Optionally take a pseudorandom-number-generator seed."""
@@ -938,6 +935,7 @@ def computeORFMatrix(psr):
 
     return ORF
 
+
 def compute_epoch_ave(times, res, err, ecorr=None, dt=1.0, flags=None):
     """Compute epoch averaged TOAs including uncertainty
 
@@ -965,7 +963,7 @@ def compute_epoch_ave(times, res, err, ecorr=None, dt=1.0, flags=None):
             bucket_ref.append(times[i])
             bucket_ind.append([i])
 
-    avetoas = N.array([N.mean(times[l]) for l in bucket_ind],'d')
+    avetoas = N.array([N.mean(times[l]) for l in bucket_ind], "d")
 
     if flags is not None:
         aveflags = N.array([flags[l[0]] for l in bucket_ind])
@@ -973,13 +971,13 @@ def compute_epoch_ave(times, res, err, ecorr=None, dt=1.0, flags=None):
     aveerr = N.zeros(len(bucket_ind))
     averes = N.zeros(len(bucket_ind))
 
-    for i,l in enumerate(bucket_ind):
+    for i, l in enumerate(bucket_ind):
         M = N.ones(len(l))
-        C = N.diag(err[l]**2)
+        C = N.diag(err[l] ** 2)
         if ecorr is not None:
             C += N.ones((len(l), len(l))) * ecorr[l[0]]
 
-        avr = 1/N.dot(M, N.dot(N.linalg.inv(C), M))
+        avr = 1 / N.dot(M, N.dot(N.linalg.inv(C), M))
         aveerr[i] = N.sqrt(avr)
         averes[i] = avr * N.dot(M, N.dot(N.linalg.inv(C), res[l]))
 


### PR DESCRIPTION
Nihan gave me some code to simulate epoch averaged TOAs.  It requires the full EFAC, EQUAD, and ECORR vectors to correctly handle the TOA uncertainty during the averaging.  His code had replacements for some libstempo functions.  This adds that functionality to `libstempo.toasim`

This also adds a function to compute epoch averaged TOAs with uncertainty based on a similar function from `PAL2`.