### PR TITLE
Some minor changes

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -22,4 +22,7 @@ include demo/libstempo-toasim-demo.ipynb
 include libstempo/data/B1953+29_NANOGrav_dfg+12.par
 include libstempo/data/B1953+29_NANOGrav_dfg+12.tim
 include libstempo/data/J1909-3744_NANOGrav_dfg+12.par 
-include libstempo/data/J1909-3744_NANOGrav_dfg+12.tim 
+include libstempo/data/J1909-3744_NANOGrav_dfg+12.tim
+include tests/test_fakepulsar.py
+include tests/test_imports.py
+include tests/test_pulsar.py

--- a/libstempo/libstempo.pyx
+++ b/libstempo/libstempo.pyx
@@ -1206,7 +1206,7 @@ cdef class tempopulsar:
             return tuple(key for key in self.pardict if self.pardict[key].set)
         elif which == 'all':
             return tuple(self.pardict)
-        elif isinstance(which,collections.Iterable):
+        elif isinstance(which,collections.abc.Iterable):
             # to support vals() with which=sequence
             return which
         else:
@@ -1226,7 +1226,7 @@ cdef class tempopulsar:
             return sum(self.pardict[par].fit for par in self.pardict if par not in self.excludepars)
 
     # --- dictionary access to parameters
-    #     TODO: possibly implement the full (nonmutable) dict interface by way of collections.Mapping
+    #     TODO: possibly implement the full (nonmutable) dict interface by way of collections.abc.Mapping
     def __contains__(self,key):
         return key in self.pardict
 
@@ -1262,10 +1262,10 @@ cdef class tempopulsar:
                 return numpy.array([self.pardict[par].val for par in self.pars(which)],numpy.object)
             else:
                 return numpy.fromiter((self.pardict[par].val for par in self.pars(which)),numpy.longdouble)
-        elif isinstance(values,collections.Mapping):
+        elif isinstance(values,collections.abc.Mapping):
             for par in values:
                 self.pardict[par].val = values[par]
-        elif isinstance(values,collections.Iterable):
+        elif isinstance(values,collections.abc.Iterable):
             for par,val in zip(self.pars(which),values):
                 self.pardict[par].val = val
         else:
@@ -1281,10 +1281,10 @@ cdef class tempopulsar:
                 return numpy.array([self.pardict[par].err for par in self.pars(which)],numpy.object)
             else:
                 return numpy.fromiter((self.pardict[par].err for par in self.pars(which)),numpy.longdouble)
-        elif isinstance(values,collections.Mapping):
+        elif isinstance(values,collections.abc.Mapping):
             for par in values:
                 self.pardict[par].err = values[par]
-        elif isinstance(values,collections.Iterable):
+        elif isinstance(values,collections.abc.Iterable):
             for par,val in zip(self.pars(which),values):
                 self.pardict[par].err = val
         else:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,9 +26,6 @@ requires = [
     "setuptools>=40.8.0",
     "wheel", # ephem package likes to have wheel installed
     "Cython>=0.22",
-    'numpy==1.15.0; python_version=="3.6"',
-    'numpy==1.15.0; python_version=="3.7"',
-    'numpy==1.17.3; python_version=="3.8"',
-    'numpy==1.19.3; python_version=="3.9"',
+    "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,8 @@ setup(
         "libstempo.spharmORFbasis",
         "libstempo.eccUtils",
     ],
-    install_requires=["Cython>=0.22", "numpy>=1.15.0", "scipy>=1.2.0", "matplotlib>=3.3.2", "ephem>=3.7.7.1"],
+    setup_requires=["cython>=0.22", "numpy"],
+    install_requires=["numpy>=1.15.0", "scipy>=1.2.0", "matplotlib>=3.3.2", "ephem>=3.7.7.1"],
     extras_require={"astropy": ["astropy>=4.1"]},
     python_requires=">=3.6",
     ext_modules=cythonize(


### PR DESCRIPTION
This PR does three main things: 

- it make the use of `collections` Python 3.10 compatible by using the `Mapping` and `Iterable` objects from the `collections.abc` submodule
- it rearranges some dependencies in the `setup.py` and `pyproject.toml` files (e.g., using the [`oldest-supported-numpy`](https://pypi.org/project/oldest-supported-numpy/) package rather than specifying version for each Python version)
- it includes the test suite scripts in the `MANIFEST.in` file so that they are distributed with the package.