### PR TITLE
Minor fix to find_tempo2_runtime

### DIFF
--- a/libstempo/_find_tempo2.py
+++ b/libstempo/_find_tempo2.py
@@ -16,9 +16,10 @@ def find_tempo2_runtime():
     """
 
     # first check for local install (i.e. from using install_tempo2.sh)
-    local_path = Path(HOME) / ".local/share/tempo2"
-    if local_path.exists():
-        return str(local_path)
+    if HOME is not None:
+        local_path = Path(HOME) / ".local/share/tempo2"
+        if local_path.exists():
+            return str(local_path)
 
     # if not, check for tempo2 binary in path
     try:


### PR DESCRIPTION
Currently, `find_tempo2_runtime` first checks a path within your home directory for the tempo2 runtime location, assuming the the `HOME` variable is a value. However, if running libstempo on a cluster node it is not necessarily the case that `HOME` is set, which means that it could be `None`. In this case the `Path(HOME)` command will fail with a `TypeError`. This minor fix only checks the local path is `HOME` is not a `None`-type.