### PR TITLE
Get rid of astropy.erfa deprecation warning

### DIFF
--- a/libstempo/libstempo.pyx
+++ b/libstempo/libstempo.pyx
@@ -44,10 +44,7 @@ try:
     from astropy.units import Quantity
     from astropy.time import Time
     import astropy.constants
-    try:
-        import astropy.erfa as erfa
-    except ImportError:
-        import astropy._erfa as erfa
+    import erfa
 
     # missing several parameters; units are discussed in tempo2/initialize.C
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,5 +2,5 @@ Cython>=0.22
 numpy>=1.15.0 
 scipy>=1.2.0
 matplotlib>=3.3.2
-astropy>=4.1
+astropy>=4.2
 ephem>=3.7.7.1


### PR DESCRIPTION
If using astropy v4.2 or higher you get a deprecation warning about importing the astropy._erfa library as erfa is now a separate package ([pyerfa](https://github.com/liberfa/pyerfa)), which is a requirement of astropy.

This PR bumps the required version of astropy for libstempo to be at least 4.2 and also imports erfa directly, thus getting rid of the deprecation warning. 