### PR TITLE
restrict cython < 3.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ exclude = '''
 requires = [
     "setuptools>=40.8.0",
     "wheel", # ephem package likes to have wheel installed
-    "Cython>=0.22",
+    "Cython>=0.22, <3.0",
     "oldest-supported-numpy",
 ]
 build-backend = "setuptools.build_meta"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Cython>=0.22
+Cython>=0.22, <3.0
 numpy>=1.15.0 
 scipy>=1.2.0
 matplotlib>=3.3.2

--- a/setup.py
+++ b/setup.py
@@ -100,7 +100,7 @@ setup(
         "libstempo.spharmORFbasis",
         "libstempo.eccUtils",
     ],
-    setup_requires=["cython>=0.22", "numpy"],
+    setup_requires=["cython>=0.22, <3.0", "numpy"],
     install_requires=["numpy>=1.15.0", "scipy>=1.2.0", "matplotlib>=3.3.2", "ephem>=3.7.7.1"],
     extras_require={"astropy": ["astropy>=4.1"]},
     python_requires=">=3.7",


### PR DESCRIPTION
Cython 3.0 breaks `libstempo` installation on PyPI. This will (temporarily) restrict to versions <3.0 until a fix can be implemented.