### PR TITLE
libstempo.pyx: add import_array

### DIFF
--- a/libstempo/libstempo.pyx
+++ b/libstempo/libstempo.pyx
@@ -37,6 +37,8 @@ from cython cimport view
 import numpy
 cimport numpy
 
+numpy.import_array()
+
 import scipy.linalg
 
 try:


### PR DESCRIPTION
Add the line:

```
numpy.import_array()
```

to the `.pyx` file as described [here](https://cython.readthedocs.io/en/latest/src/tutorial/numpy.html#adding-types), otherwise Cython 3 builds with NumPy v2 can fail.