### PR TITLE
Update license info to new style specification

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,11 +25,11 @@ description = "A Python wrapper for tempo2"
 authors = [{name = "Michele Vallisneri", email = "vallis@vallis.org"}]
 urls = { Homepage = "https://github.com/vallis/libstempo" }
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
+license-files = [ "LICENSE" ] 
 classifiers=[
     "Intended Audience :: Developers",
     "Intended Audience :: Science/Research",
-    "License :: OSI Approved :: MIT License",
     "Operating System :: MacOS",
     "Operating System :: POSIX :: Linux",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
This updates the pyproject.toml to use the [PEP639](https://peps.python.org/pep-0639/) convention for license information over the now deprecated [PEP621](https://peps.python.org/pep-0621/#license) style - see https://packaging.python.org/en/latest/guides/writing-pyproject-toml/#license.