### PR TITLE
fix(ci): pin macOS CI to x86_64 — tempo2 requires 128-bit long double

### DIFF
--- a/.github/workflows/ci_tests.yml
+++ b/.github/workflows/ci_tests.yml
@@ -8,7 +8,7 @@ on:
     branches: [ master ]
   pull_request:
     branches: [ master ]
-  release: 
+  release:
     types:
       - published
 
@@ -19,26 +19,37 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, macos-latest]
-        python-version: ['3.8', '3.9', '3.10', '3.11', '3.12']
+        os: [ubuntu-latest, macos-15-intel]
+        python-version: ['3.10', '3.11', '3.12', '3.13']
+        include:
+          - os: ubuntu-latest
+            python-version: '3.9'
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v2
+      uses: actions/checkout@v4
     - name: Set up Python ${{ matrix.python-version }}
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install tempo2 on mac
       if: runner.os == 'macOS'
       run: |
-        brew unlink gcc && brew link gcc
-        brew install automake libtool
+        brew install automake libtool gcc
+        sudo ln -sf "$(brew --prefix gcc)/bin/gfortran-$(brew list --versions gcc | awk '{print $2}' | cut -d. -f1)" /usr/local/bin/gfortran
+        gfortran --version
         ./install_tempo2.sh
+        echo "TEMPO2_PREFIX=$HOME/.local" >> "$GITHUB_ENV"
+        echo "--- tempo2 install verification ---"
+        ls -la "$HOME/.local/include/" || echo "WARNING: $HOME/.local/include/ does not exist"
+        ls -la "$HOME/.local/lib/"     || echo "WARNING: $HOME/.local/lib/ does not exist"
+        test -f "$HOME/.local/include/tempo2.h" || { echo "FATAL: tempo2.h not found at $HOME/.local/include/tempo2.h"; exit 1; }
     - name: Install tempo2 on linux
       if: runner.os == 'Linux'
       run: |
         ./install_tempo2.sh
+        echo "TEMPO2_PREFIX=$HOME/.local" >> "$GITHUB_ENV"
+        test -f "$HOME/.local/include/tempo2.h" || { echo "FATAL: tempo2.h not found at $HOME/.local/include/tempo2.h"; exit 1; }
     - name: Install dependencies and package
       run: |
         python -m pip install --upgrade pip
@@ -55,21 +66,15 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-    - uses: actions/checkout@v2
-    - name: Set up Python 
-      uses: actions/setup-python@v2
+    - uses: actions/checkout@v4
+    - name: Set up Python
+      uses: actions/setup-python@v5
       with:
-        python-version: '3.10'
-    - name: Install tempo2 on mac
-      if: runner.os == 'macOS'
-      run: |
-        brew unlink gcc && brew link gcc
-        brew install automake
-        ./install_tempo2.sh
-    - name: Install tempo2 on linux
-      if: runner.os == 'Linux'
+        python-version: '3.12'
+    - name: Install tempo2
       run: |
         ./install_tempo2.sh
+        echo "TEMPO2_PREFIX=$HOME/.local" >> "$GITHUB_ENV"
     - name: Build
       run: |
         python -m pip install --upgrade pip setuptools wheel build
@@ -77,7 +82,7 @@ jobs:
         make dist
     - name: Test the sdist
       run: |
-        mkdir tmp  
+        mkdir tmp
         cd tmp
         python -m venv venv-sdist
         venv-sdist/bin/python -m pip install --upgrade pip setuptools
@@ -94,9 +99,9 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event_name == 'release'
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v4
     - name: Set up Python
-      uses: actions/setup-python@v2
+      uses: actions/setup-python@v5
       with:
         python-version: '3.x'
     - name: Install dependencies
@@ -104,7 +109,7 @@ jobs:
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
     - name: Download wheel/dist from build
-      uses: actions/download-artifact@v4.1.7
+      uses: actions/download-artifact@v4
       with:
         name: dist
         path: dist

--- a/install_tempo2.sh
+++ b/install_tempo2.sh
@@ -20,15 +20,18 @@ tar zxvf 2021.07.1-correct.tar.gz
 cd psrsoft-tempo2-*
 
 # remove LT_LIB_DLLOAD from configure.ac
-sed_in_place="-i ''" # For macOS
-if [[ "$(uname -s)" == "Linux" ]]; then
-  sed_in_place="-i"   # For Linux
+if [[ "$(uname -s)" == "Darwin" ]]; then
+  sed -i '' "s/LT_LIB_DLLOAD//g" "configure.ac"
+else
+  sed -i "s/LT_LIB_DLLOAD//g" "configure.ac"
 fi
-sed "$sed_in_place" "s/LT_LIB_DLLOAD//g" "configure.ac"
 
 ./bootstrap
-./configure --prefix=$prefix
-make && make install
+# Prevent autoconf from enabling C23 (where bool is a keyword),
+# which breaks tempo2's jpleph.c `typedef int bool;`
+./configure --prefix=$prefix ac_cv_prog_cc_c23=no
+make
+make install
 cp -r T2runtime/* $TEMPO2
 cd ..
 


### PR DESCRIPTION
Fixes #83 

**Summary**

* Pin macOS CI to `macos-15-intel `(x86_64). tempo2 requires 128-bit `long double` which arm64 macOS does not provide.
* Update GitHub Actions to current major versions (checkout v4, setup-python v5, download-artifact v4)
* Set `TEMPO2_PREFIX` via `$GITHUB_ENV` so it survives pip build isolation
* Fix brew commands and BSD sed quoting in `install_tempo2.sh`
* Drop Python 3.8 (EOL); add Python 3.13; keep 3.9 on Linux only